### PR TITLE
Fix regex limiting branch builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,7 @@ image: Visual Studio 2017
 
 branches:
     only:
-        - master
-        - /[0-9]+\.[0-9]+\.[0-9]+(-.+)?/
+        - /^(master|[1-9][0-9]*\.[1-9][0-9]*\.[1-9][0-9]*(-.+)?)$/
 
 pull_requests:
     do_not_increment_build_number: true


### PR DESCRIPTION
It was building any branch that contained numbers like x.y.z.