### PR TITLE
Use custom rules to configure fake services

### DIFF
--- a/src/SelfInitializingFakes/Infrastructure/PlaybackRule.cs
+++ b/src/SelfInitializingFakes/Infrastructure/PlaybackRule.cs
@@ -1,0 +1,60 @@
+namespace SelfInitializingFakes.Infrastructure
+{
+    using System.Collections.Generic;
+    using FakeItEasy.Core;
+
+    internal class PlaybackRule : IFakeObjectCallRule
+    {
+        private Queue<RecordedCall> expectedCalls;
+
+        public PlaybackRule(Queue<RecordedCall> expectedCalls)
+        {
+            this.expectedCalls = expectedCalls;
+        }
+
+        public int? NumberOfTimesToCall => null;
+
+        public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
+        {
+            RecordedCall recordedCall = this.ConsumeNextExpectedCall(fakeObjectCall);
+            SetReturnValue(fakeObjectCall, recordedCall);
+            SetOutAndRefValues(fakeObjectCall, recordedCall);
+        }
+
+        public bool IsApplicableTo(IFakeObjectCall fakeObjectCall) => true;
+
+        private RecordedCall ConsumeNextExpectedCall(IFakeObjectCall call)
+        {
+            if (this.expectedCalls.Count == 0)
+            {
+                throw new PlaybackException($"expected no more calls, but found [{call.Method}]");
+            }
+
+            var expectedCall = this.expectedCalls.Dequeue();
+            if (expectedCall.Method != call.Method.ToString())
+            {
+                throw new PlaybackException($"expected a call to [{expectedCall.Method}], but found [{call.Method}]");
+            }
+
+            return expectedCall;
+        }
+
+        private static void SetReturnValue(IInterceptedFakeObjectCall fakeObjectCall, RecordedCall recordedCall)
+        {
+            fakeObjectCall.SetReturnValue(recordedCall.ReturnValue);
+        }
+
+        private static void SetOutAndRefValues(IInterceptedFakeObjectCall fakeObjectCall, RecordedCall recordedCall)
+        {
+            int outOrRefIndex = 0;
+            for (int parameterIndex = 0; parameterIndex < fakeObjectCall.Method.GetParameters().Length; parameterIndex++)
+            {
+                var parameter = fakeObjectCall.Method.GetParameters()[parameterIndex];
+                if (parameter.ParameterType.IsByRef)
+                {
+                    fakeObjectCall.SetArgumentValue(parameterIndex, recordedCall.OutAndRefValues[outOrRefIndex++]);
+                }
+            }
+        }
+    }
+}

--- a/src/SelfInitializingFakes/Infrastructure/RecordingRule.cs
+++ b/src/SelfInitializingFakes/Infrastructure/RecordingRule.cs
@@ -1,0 +1,87 @@
+namespace SelfInitializingFakes.Infrastructure
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using FakeItEasy.Core;
+
+    internal class RecordingRule : IFakeObjectCallRule
+    {
+        private readonly object target;
+
+        public RecordingRule(object target)
+        {
+            this.target = target;
+        }
+
+        public int? NumberOfTimesToCall => null;
+
+        public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
+        {
+            try
+            {
+                var recordedCall = BuildRecordedCall(fakeObjectCall);
+                this.RecordedCalls.Add(recordedCall);
+                ApplyRecordedCall(recordedCall, fakeObjectCall);
+            }
+            catch (Exception e)
+            {
+                var serviceException = e.InnerException ?? e;
+                if (this.RecordingException == null)
+                {
+                    this.RecordingException = serviceException;
+                }
+
+                serviceException.Rethrow();
+            }
+        }
+
+        public bool IsApplicableTo(IFakeObjectCall fakeObjectCall) => true;
+
+        public Exception RecordingException { get; set; }
+
+        public IList<RecordedCall> RecordedCalls { get; } = new List<RecordedCall>();
+
+        private static void ApplyRecordedCall(RecordedCall recordedCall, IInterceptedFakeObjectCall fakeObjectCall)
+        {
+            fakeObjectCall.SetReturnValue(recordedCall.ReturnValue);
+
+            int outAndRefIndex = 0;
+            int parameterIndex = 0;
+            foreach (var parameter in fakeObjectCall.Method.GetParameters())
+            {
+                if (parameter.ParameterType.IsByRef)
+                {
+                    fakeObjectCall.SetArgumentValue(parameterIndex, recordedCall.OutAndRefValues[outAndRefIndex++]);
+                }
+
+                ++parameterIndex;
+            }
+        }
+
+        private RecordedCall BuildRecordedCall(IFakeObjectCall call)
+        {
+            var arguments = call.Arguments.ToArray();
+            var result = call.Method.Invoke(this.target, arguments);
+
+            var outAndRefValues = new List<object>();
+            int index = 0;
+            foreach (var parameter in call.Method.GetParameters())
+            {
+                if (parameter.ParameterType.IsByRef)
+                {
+                    outAndRefValues.Add(arguments[index]);
+                }
+
+                ++index;
+            }
+
+            return new RecordedCall
+            {
+                Method = call.Method.ToString(),
+                ReturnValue = result,
+                OutAndRefValues = outAndRefValues.ToArray(),
+            };
+        }
+    }
+}

--- a/src/SelfInitializingFakes/SelfInitializingFake.of.T.cs
+++ b/src/SelfInitializingFakes/SelfInitializingFake.of.T.cs
@@ -3,13 +3,8 @@ namespace SelfInitializingFakes
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Linq;
-#if FEATURE_NETCORE_REFLECTION
-    using System.Reflection;
-#endif
     using FakeItEasy;
     using FakeItEasy.Core;
-    using FakeItEasy.Creation;
     using SelfInitializingFakes.Infrastructure;
 
     /// <summary>
@@ -29,9 +24,7 @@ namespace SelfInitializingFakes
             new ConcurrentDictionary<IFakeObjectCall, object[]>();
 
         private readonly IRecordedCallRepository repository;
-        private readonly IList<RecordedCall> recordedCalls;
-        private readonly Queue<RecordedCall> expectedCalls;
-        private Exception recordingException;
+        private readonly RecordingRule recordingRule;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SelfInitializingFake{TService}"/> class.
@@ -45,27 +38,20 @@ namespace SelfInitializingFakes
                 throw new ArgumentNullException(nameof(serviceFactory));
             }
 
-            if (repository == null)
-            {
-                throw new ArgumentNullException(nameof(repository));
-            }
-
-            this.repository = repository;
+            this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
 
             var callsFromRepository = this.repository.Load();
             if (callsFromRepository == null)
             {
                 var wrappedService = serviceFactory.Invoke();
-
-                this.Object = A.Fake(CreateWrapper(wrappedService));
-                this.recordedCalls = new List<RecordedCall>();
-                this.AddRecordingRulesToFake(wrappedService);
+                this.Object = A.Fake<TService>();
+                this.recordingRule = new RecordingRule(wrappedService);
+                Fake.GetFakeManager(this.Object).AddRuleFirst(this.recordingRule);
             }
             else
             {
                 this.Object = A.Fake<TService>();
-                this.expectedCalls = new Queue<RecordedCall>(callsFromRepository);
-                this.AddPlaybackRulesToFake();
+                Fake.GetFakeManager(this.Object).AddRuleFirst(new PlaybackRule(new Queue<RecordedCall>(callsFromRepository)));
             }
         }
 
@@ -94,27 +80,11 @@ namespace SelfInitializingFakes
             return new SelfInitializingFake<TService>(() => serviceFactory.Invoke(), repository);
         }
 
-        Action<IFakeOptions<TService>> CreateWrapper(TService wrappedService)
-        {
-            return options =>
-            {
-#if FEATURE_NETCORE_REFLECTION
-                var optionsType = options.GetType().GetTypeInfo();
-#else
-                var optionsType = options.GetType();
-#endif
-                var wrapping = optionsType.GetMethod("Wrapping", new[] { typeof(TService) });
-                wrapping.Invoke(options, new object[] { wrappedService });
-            };
-        }
-
         /// <summary>
         /// Gets the fake <typeparamref name="TService"/> to be used in tests.
         /// </summary>
         /// <value>The fake <typeparamref name="TService"/> to be used in tests.</value>
         public TService Object { get; }
-
-        private bool IsRecording => this.recordedCalls != null;
 
         /// <summary>
         /// Ends a recording or playback session.
@@ -125,142 +95,25 @@ namespace SelfInitializingFakes
         {
             if (this.IsRecording)
             {
-                if (this.recordingException != null)
+                if (this.recordingRule.RecordingException != null)
                 {
                     throw new PlaybackException(
                         "error encountered while recording actual service calls",
-                        this.recordingException);
+                        this.recordingRule.RecordingException);
                 }
 
-                this.repository.Save(this.recordedCalls);
+                this.repository.Save(this.recordingRule.RecordedCalls);
             }
 
             this.AddDisposedRecordingRuleToFake();
         }
 
-        private static object[] GetOutAndRefValues(IFakeObjectCall call)
-        {
-            object[] outAndRefValues;
-            OutAndRefValuesCache.TryRemove(call, out outAndRefValues);
-            return outAndRefValues;
-        }
-
-        private static RecordedCall BuildRecordedCall<TClass>(IFakeObjectCall call, TClass target)
-        {
-            var arguments = call.Arguments.ToArray();
-            var result = call.Method.Invoke(target, arguments);
-
-            var outAndRefValues = new List<object>();
-            int index = 0;
-            foreach (var parameter in call.Method.GetParameters())
-            {
-                if (parameter.ParameterType.IsByRef)
-                {
-                    outAndRefValues.Add(arguments[index]);
-                }
-
-                ++index;
-            }
-
-            return new RecordedCall
-            {
-                Method = call.Method.ToString(),
-                ReturnValue = result,
-                OutAndRefValues = outAndRefValues.ToArray(),
-            };
-        }
-
-        private RecordedCall ConsumeNextExpectedCall(IFakeObjectCall call)
-        {
-            if (this.expectedCalls.Count == 0)
-            {
-                throw new PlaybackException($"expected no more calls, but found [{call.Method}]");
-            }
-
-            var expectedCall = this.expectedCalls.Dequeue();
-            if (expectedCall.Method != call.Method.ToString())
-            {
-                throw new PlaybackException($"expected a call to [{expectedCall.Method}], but found [{call.Method}]");
-            }
-
-            return expectedCall;
-        }
-
-        private void AddRecordingRulesToFake<TClass>(TClass target)
-        {
-            // This rule applies to all calls to the fake, but is
-            // overridden for calls with return values belowe.
-            A.CallTo(this.Object).AssignsOutAndRefParametersLazily(call =>
-            {
-                try
-                {
-                    var recordedCall = BuildRecordedCall(call, target);
-                    this.recordedCalls.Add(recordedCall);
-                    return recordedCall.OutAndRefValues;
-                }
-                catch (Exception e)
-                {
-                    var serviceException = e.InnerException ?? e;
-                    if (this.recordingException == null)
-                    {
-                        this.recordingException = serviceException;
-                    }
-
-                    serviceException.Rethrow();
-                    return null; // to satisfy the compiler
-                }
-            });
-
-            // This rule relies on an undocumented FakeItEasy behavior: that
-            // the actions specified in AssignsOutAndRefParametersLazily will
-            // be invoked after ReturnsLazily.
-            A.CallTo(this.Object).WithNonVoidReturnType()
-                .ReturnsLazily(call =>
-                {
-                    try
-                    {
-                        var recordedCall = BuildRecordedCall(call, target);
-                        OutAndRefValuesCache[call] = recordedCall.OutAndRefValues;
-                        this.recordedCalls.Add(recordedCall);
-                        return recordedCall.ReturnValue;
-                    }
-                    catch (Exception e)
-                    {
-                        var serviceException = e.InnerException ?? e;
-                        if (this.recordingException == null)
-                        {
-                            this.recordingException = serviceException;
-                        }
-
-                        serviceException.Rethrow();
-                        return null; // to satisfy the compiler
-                    }
-                })
-                .AssignsOutAndRefParametersLazily(GetOutAndRefValues);
-        }
+        private bool IsRecording => this.recordingRule != null;
 
         private void AddDisposedRecordingRuleToFake()
         {
             A.CallTo(this.Object)
                 .Throws(new RecordingException("The fake has been disposed and can record no more calls."));
-        }
-
-        private void AddPlaybackRulesToFake()
-        {
-            A.CallTo(this.Object)
-                .AssignsOutAndRefParametersLazily(call => this.ConsumeNextExpectedCall(call).OutAndRefValues);
-
-            // This rule relies on an undocumented FakeItEasy behavior: that
-            // the actions specified in AssignsOutAndRefParametersLazily will
-            // be invoked after ReturnsLazily.
-            A.CallTo(this.Object).WithNonVoidReturnType()
-                .ReturnsLazily(call =>
-                {
-                    RecordedCall recordedCall = this.ConsumeNextExpectedCall(call);
-                    OutAndRefValuesCache[call] = recordedCall.OutAndRefValues;
-                    return recordedCall.ReturnValue;
-                })
-                .AssignsOutAndRefParametersLazily(GetOutAndRefValues);
         }
     }
 }


### PR DESCRIPTION
Avoids the need to use reflection access the "wrapping" functionality, and also means we don't have to rely on the undocumented behaviour of return values being set before actions are invoked.