### PR TITLE
Only fake reference types

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,8 @@
+### Changed
+
+- Require faked services to be reference types, enforced by compiler
+  ([#68](https://github.com/blairconrad/SelfInitializingFakes/pull/68))
+
 ### Additional Items
 
 - Use [Bullseye](https://github.com/adamralph/bullseye) 2.3.0 to provide coloured build output on Windows ([#59](https://github.com/blairconrad/SelfInitializingFakes/pull/59), [#67](https://github.com/blairconrad/SelfInitializingFakes/pull/67))

--- a/src/SelfInitializingFakes/SelfInitializingFake.of.T.cs
+++ b/src/SelfInitializingFakes/SelfInitializingFake.of.T.cs
@@ -12,6 +12,7 @@ namespace SelfInitializingFakes
     /// </summary>
     /// <typeparam name="TService">The type of the service to fake.</typeparam>
     public sealed class SelfInitializingFake<TService> : IDisposable
+        where TService : class
     {
         private readonly IRecordedCallRepository repository;
         private readonly RecordingRule recordingRule;


### PR DESCRIPTION
Any attempt to fake a value type will fail anyhow. And FakeItEasy 5.0.0 will enforce this restriction, so let's be ready.