### PR TITLE
[WIP] Convert Task and Lazys so they can be (de)serialized

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,8 @@
 
 - Allow multiple path components in file-based recorded call repository constructors ([#88](https://github.com/blairconrad/SelfInitializingFakes/pull/88))
 - Create missing directories for file-based recorded call repositories ([#87](https://github.com/blairconrad/SelfInitializingFakes/pull/87))
+- Serialize `Lazy<T>`, `Task`, and `Task<T>` return values and out and ref
+  parameters ([#81](https://github.com/blairconrad/SelfInitializingFakes/issues/81))
 
 ### With special thanks for contributions to this release from:
 - [CableZa](https://github.com/CableZa)

--- a/src/SelfInitializingFakes/Infrastructure/CompoundTypeConverter.cs
+++ b/src/SelfInitializingFakes/Infrastructure/CompoundTypeConverter.cs
@@ -26,21 +26,23 @@ namespace SelfInitializingFakes.Infrastructure
         /// Potentially converts an unserializable object to a more serializable form.
         /// </summary>
         /// <param name="input">An input object.</param>
+        /// <param name="mainConverter">A comprehensive converter that may be used to further convert the output, if required.</param>
         /// <param name="output">An output object. Will be assigned to a simpler representation of <paramref name="input"/>, if this converter knows how.</param>
         /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
-        public bool ConvertForRecording(object? input, out object? output) =>
-            this.first.ConvertForRecording(input, out output) ||
-            this.second.ConvertForRecording(input, out output);
+        public bool ConvertForRecording(object? input, ITypeConverter mainConverter, out object? output) =>
+            this.first.ConvertForRecording(input, mainConverter, out output) ||
+            this.second.ConvertForRecording(input, mainConverter, out output);
 
         /// <summary>
         /// Potentially converts the serializable form of an object back to its unserializable form.
         /// </summary>
         /// <param name="deserializedType">The desired deserialized type.</param>
         /// <param name="input">An input object.</param>
+        /// <param name="mainConverter">A comprehensive converter that may be used to further convert the output, if required.</param>
         /// <param name="output">An output object. Will be reconstituted from its simpler representation as <paramref name="input"/>, if this converter knows how.</param>
         /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
-        public bool ConvertForPlayback(Type deserializedType, object? input, out object? output) =>
-            this.first.ConvertForPlayback(deserializedType, input, out output) ||
-            this.second.ConvertForPlayback(deserializedType, input, out output);
+        public bool ConvertForPlayback(Type deserializedType, object? input, ITypeConverter mainConverter, out object? output) =>
+            this.first.ConvertForPlayback(deserializedType, input, mainConverter, out output) ||
+            this.second.ConvertForPlayback(deserializedType, input, mainConverter, out output);
     }
 }

--- a/src/SelfInitializingFakes/Infrastructure/CompoundTypeConverter.cs
+++ b/src/SelfInitializingFakes/Infrastructure/CompoundTypeConverter.cs
@@ -1,0 +1,46 @@
+namespace SelfInitializingFakes.Infrastructure
+{
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    /// Chains other <see cref="ITypeConverter"/>s together.
+    /// </summary>
+    internal class CompoundTypeConverter : ITypeConverter
+    {
+        private readonly ITypeConverter first;
+        private readonly ITypeConverter second;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompoundTypeConverter"/> class.
+        /// </summary>
+        /// <param name="first">The first converter to try. If it can't convert the input, the second will be tried.</param>
+        /// <param name="second">The second converter to try, if the first was unable.</param>
+        public CompoundTypeConverter(ITypeConverter first, ITypeConverter second)
+        {
+            this.first = first;
+            this.second = second;
+        }
+
+        /// <summary>
+        /// Potentially converts an unserializable object to a more serializable form.
+        /// </summary>
+        /// <param name="input">An input object.</param>
+        /// <param name="output">An output object. Will be assigned to a simpler representation of <paramref name="input"/>, if this converter knows how.</param>
+        /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
+        public bool ConvertForRecording(object? input, out object? output) =>
+            this.first.ConvertForRecording(input, out output) ||
+            this.second.ConvertForRecording(input, out output);
+
+        /// <summary>
+        /// Potentially converts the serializable form of an object back to its unserializable form.
+        /// </summary>
+        /// <param name="deserializedType">The desired deserialized type.</param>
+        /// <param name="input">An input object.</param>
+        /// <param name="output">An output object. Will be reconstituted from its simpler representation as <paramref name="input"/>, if this converter knows how.</param>
+        /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
+        public bool ConvertForPlayback(Type deserializedType, object? input, out object? output) =>
+            this.first.ConvertForPlayback(deserializedType, input, out output) ||
+            this.second.ConvertForPlayback(deserializedType, input, out output);
+    }
+}

--- a/src/SelfInitializingFakes/Infrastructure/ITypeConverter.cs
+++ b/src/SelfInitializingFakes/Infrastructure/ITypeConverter.cs
@@ -1,0 +1,27 @@
+namespace SelfInitializingFakes.Infrastructure
+{
+    using System;
+
+    /// <summary>
+    /// Converts unserializable types to simpler types while recording, and reverses the transformation during.
+    /// </summary>
+    internal interface ITypeConverter
+    {
+        /// <summary>
+        /// Potentially converts an unserializable object to a more serializable form.
+        /// </summary>
+        /// <param name="input">An input object.</param>
+        /// <param name="output">An output object. Will be assigned to a simpler representation of <paramref name="input"/>, if this converter knows how.</param>
+        /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
+        bool ConvertForRecording(object? input, out object? output);
+
+        /// <summary>
+        /// Potentially converts the serializable form of an object back to its unserializable form.
+        /// </summary>
+        /// <param name="deserializedType">The desired deserialized type.</param>
+        /// <param name="input">An input object.</param>
+        /// <param name="output">An output object. Will be reconstituted from its simpler representation as <paramref name="input"/>, if this converter knows how.</param>
+        /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
+        bool ConvertForPlayback(Type deserializedType, object? input, out object? output);
+    }
+}

--- a/src/SelfInitializingFakes/Infrastructure/ITypeConverter.cs
+++ b/src/SelfInitializingFakes/Infrastructure/ITypeConverter.cs
@@ -11,17 +11,19 @@ namespace SelfInitializingFakes.Infrastructure
         /// Potentially converts an unserializable object to a more serializable form.
         /// </summary>
         /// <param name="input">An input object.</param>
+        /// <param name="mainConverter">A comprehensive converter that may be used to further convert the output, if required.</param>
         /// <param name="output">An output object. Will be assigned to a simpler representation of <paramref name="input"/>, if this converter knows how.</param>
         /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
-        bool ConvertForRecording(object? input, out object? output);
+        bool ConvertForRecording(object? input, ITypeConverter mainConverter, out object? output);
 
         /// <summary>
         /// Potentially converts the serializable form of an object back to its unserializable form.
         /// </summary>
         /// <param name="deserializedType">The desired deserialized type.</param>
         /// <param name="input">An input object.</param>
+        /// <param name="mainConverter">A comprehensive converter that may be used to further convert the output, if required.</param>
         /// <param name="output">An output object. Will be reconstituted from its simpler representation as <paramref name="input"/>, if this converter knows how.</param>
         /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
-        bool ConvertForPlayback(Type deserializedType, object? input, out object? output);
+        bool ConvertForPlayback(Type deserializedType, object? input, ITypeConverter mainConverter, out object? output);
     }
 }

--- a/src/SelfInitializingFakes/Infrastructure/LazyTypeConverter.cs
+++ b/src/SelfInitializingFakes/Infrastructure/LazyTypeConverter.cs
@@ -1,0 +1,61 @@
+namespace SelfInitializingFakes.Infrastructure
+{
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    /// Converts <see cref="System.Lazy{T}" /> types to simpler types for serialization, and back again.
+    /// </summary>
+    internal class LazyTypeConverter : ITypeConverter
+    {
+        private static readonly MethodInfo CreateLazyGenericDefinition =
+           typeof(LazyTypeConverter).GetMethod(nameof(CreateLazy), BindingFlags.Static | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// Potentially converts an unserializable object to a more serializable form.
+        /// </summary>
+        /// <param name="input">An input object.</param>
+        /// <param name="output">An output object. Will be assigned to a simpler representation of <paramref name="input"/>, if this converter knows how.</param>
+        /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
+        public bool ConvertForRecording(object? input, out object? output)
+        {
+            output = null;
+            if (input is null)
+            {
+                return false;
+            }
+
+            var inputType = input.GetType();
+            if (inputType.IsInstanceOf(typeof(Lazy<>)))
+            {
+                output = inputType.GetProperty("Value").GetGetMethod().Invoke(input, Type.EmptyTypes);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Potentially converts the serializable form of an object back to its unserializable form.
+        /// </summary>
+        /// <param name="deserializedType">The desired deserialized type.</param>
+        /// <param name="input">An input object.</param>
+        /// <param name="output">An output object. Will be reconstituted from its simpler representation as <paramref name="input"/>, if this converter knows how.</param>
+        /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
+        public bool ConvertForPlayback(Type deserializedType, object? input, out object? output)
+        {
+            if (deserializedType.IsInstanceOf(typeof(Lazy<>)))
+            {
+                var typeOfLazyResult = deserializedType.GetGenericArguments()[0];
+                var method = CreateLazyGenericDefinition.MakeGenericMethod(typeOfLazyResult);
+                output = method.Invoke(null, new object?[] { input });
+                return true;
+            }
+
+            output = null;
+            return false;
+        }
+
+        private static Lazy<T> CreateLazy<T>(T value) => new Lazy<T>(() => value);
+    }
+}

--- a/src/SelfInitializingFakes/Infrastructure/PlaybackRule.cs
+++ b/src/SelfInitializingFakes/Infrastructure/PlaybackRule.cs
@@ -50,7 +50,7 @@ namespace SelfInitializingFakes.Infrastructure
         private void SetReturnValue(IInterceptedFakeObjectCall fakeObjectCall, RecordedCall recordedCall)
         {
             var returnValue = recordedCall.ReturnValue;
-            if (this.typeConverter.ConvertForPlayback(fakeObjectCall.Method.ReturnType, returnValue, out object? convertedReturnValue))
+            if (this.typeConverter.ConvertForPlayback(fakeObjectCall.Method.ReturnType, returnValue, this.typeConverter, out object? convertedReturnValue))
             {
                 returnValue = convertedReturnValue;
             }
@@ -70,6 +70,7 @@ namespace SelfInitializingFakes.Infrastructure
                     if (this.typeConverter.ConvertForPlayback(
                             parameter.ParameterType.GetElementType(),
                             parameterValue,
+                            this.typeConverter,
                             out object? convertedParameterValue))
                     {
                         parameterValue = convertedParameterValue;

--- a/src/SelfInitializingFakes/Infrastructure/RecordingRule.cs
+++ b/src/SelfInitializingFakes/Infrastructure/RecordingRule.cs
@@ -125,14 +125,14 @@ namespace SelfInitializingFakes.Infrastructure
 
         private void ConvertRecordedCallForSerialization(RecordedCall call)
         {
-            if (this.typeConverter.ConvertForRecording(call.ReturnValue, out object? convertedReturnValue))
+            if (this.typeConverter.ConvertForRecording(call.ReturnValue, this.typeConverter, out object? convertedReturnValue))
             {
                 call.ReturnValue = convertedReturnValue;
             }
 
             for (int i = 0; i < call.OutAndRefValues.Length; ++i)
             {
-                if (this.typeConverter.ConvertForRecording(call.OutAndRefValues[i], out object? convertedValue))
+                if (this.typeConverter.ConvertForRecording(call.OutAndRefValues[i], this.typeConverter, out object? convertedValue))
                 {
                     call.OutAndRefValues[i] = convertedValue;
                 }

--- a/src/SelfInitializingFakes/Infrastructure/RecordingRule.cs
+++ b/src/SelfInitializingFakes/Infrastructure/RecordingRule.cs
@@ -13,15 +13,18 @@ namespace SelfInitializingFakes.Infrastructure
     internal class RecordingRule : IFakeObjectCallRule
     {
         private readonly object target;
+        private readonly ITypeConverter typeConverter;
         private Exception? recordingException;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RecordingRule"/> class.
         /// </summary>
         /// <param name="target">The object to which to forward calls, in order to harvest return, out, and ref values.</param>
-        public RecordingRule(object target)
+        /// <param name="typeConverter">A helper to convert values from their original representation to serializable variants.</param>
+        public RecordingRule(object target, ITypeConverter typeConverter)
         {
             this.target = target;
+            this.typeConverter = typeConverter;
         }
 
         /// <summary>
@@ -52,8 +55,9 @@ namespace SelfInitializingFakes.Infrastructure
             try
             {
                 var recordedCall = this.BuildRecordedCall(fakeObjectCall);
-                this.RecordedCalls.Add(recordedCall);
                 ApplyRecordedCall(recordedCall, fakeObjectCall);
+                this.ConvertRecordedCallForSerialization(recordedCall);
+                this.RecordedCalls.Add(recordedCall);
             }
 #pragma warning disable CA1031 // We do rethrow the exception
             catch (Exception e)
@@ -117,6 +121,22 @@ namespace SelfInitializingFakes.Infrastructure
             }
 
             return new RecordedCall(call.Method.ToString(), result, outAndRefValues.ToArray());
+        }
+
+        private void ConvertRecordedCallForSerialization(RecordedCall call)
+        {
+            if (this.typeConverter.ConvertForRecording(call.ReturnValue, out object? convertedReturnValue))
+            {
+                call.ReturnValue = convertedReturnValue;
+            }
+
+            for (int i = 0; i < call.OutAndRefValues.Length; ++i)
+            {
+                if (this.typeConverter.ConvertForRecording(call.OutAndRefValues[i], out object? convertedValue))
+                {
+                    call.OutAndRefValues[i] = convertedValue;
+                }
+            }
         }
     }
 }

--- a/src/SelfInitializingFakes/Infrastructure/TaskTypeConverter.cs
+++ b/src/SelfInitializingFakes/Infrastructure/TaskTypeConverter.cs
@@ -16,9 +16,10 @@ namespace SelfInitializingFakes.Infrastructure
         /// Potentially converts an unserializable object to a more serializable form.
         /// </summary>
         /// <param name="input">An input object.</param>
+        /// <param name="mainConverter">A comprehensive converter that may be used to further convert the output, if required.</param>
         /// <param name="output">An output object. Will be assigned to a simpler representation of <paramref name="input"/>, if this converter knows how.</param>
         /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
-        public bool ConvertForRecording(object? input, out object? output)
+        public bool ConvertForRecording(object? input, ITypeConverter mainConverter, out object? output)
         {
             output = null;
             if (input is null)
@@ -30,11 +31,21 @@ namespace SelfInitializingFakes.Infrastructure
             if (inputType.IsInstanceOf(typeof(Task<>)))
             {
                 output = inputType.GetProperty("Result").GetGetMethod().Invoke(input, Type.EmptyTypes);
+                if (mainConverter.ConvertForRecording(output, mainConverter, out object? furtherConvertedOutput))
+                {
+                    output = furtherConvertedOutput;
+                }
+
                 return true;
             }
             else if (inputType == typeof(Task))
             {
                 output = "{void Task}";
+                if (mainConverter.ConvertForRecording(output, mainConverter, out object? furtherConvertedOutput))
+                {
+                    output = furtherConvertedOutput;
+                }
+
                 return true;
             }
 
@@ -46,16 +57,28 @@ namespace SelfInitializingFakes.Infrastructure
         /// </summary>
         /// <param name="deserializedType">The desired deserialized type.</param>
         /// <param name="input">An input object.</param>
+        /// <param name="mainConverter">A comprehensive converter that may be used to further convert the output, if required.</param>
         /// <param name="output">An output object. Will be reconstituted from its simpler representation as <paramref name="input"/>, if this converter knows how.</param>
         /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
-        public bool ConvertForPlayback(Type deserializedType, object? input, out object? output)
+        public bool ConvertForPlayback(Type deserializedType, object? input, ITypeConverter mainConverter, out object? output)
         {
             if (deserializedType.IsInstanceOf(typeof(Task<>)))
             {
                 var typeOfTaskResult = deserializedType.GetGenericArguments()[0];
-                var method = CreateTaskGenericDefinition.MakeGenericMethod(typeOfTaskResult);
-                output = method.Invoke(null, new object?[] { input });
-                return true;
+
+                if (input is null || input.GetType() == typeOfTaskResult)
+                {
+                    var method = CreateTaskGenericDefinition.MakeGenericMethod(typeOfTaskResult);
+                    output = method.Invoke(null, new object?[] { input });
+                    return true;
+                }
+
+                if (mainConverter.ConvertForPlayback(typeOfTaskResult, input, mainConverter, out object? convertedInput))
+                {
+                    var method = CreateTaskGenericDefinition.MakeGenericMethod(typeOfTaskResult);
+                    output = method.Invoke(null, new object?[] { convertedInput });
+                    return true;
+                }
             }
             else if (deserializedType == typeof(Task) && "{void Task}".Equals(input))
             {

--- a/src/SelfInitializingFakes/Infrastructure/TaskTypeConverter.cs
+++ b/src/SelfInitializingFakes/Infrastructure/TaskTypeConverter.cs
@@ -1,0 +1,81 @@
+namespace SelfInitializingFakes.Infrastructure
+{
+    using System;
+    using System.Reflection;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Converts <see cref="Task{T}" /> types to simpler types for serialization, and back again.
+    /// </summary>
+    internal class TaskTypeConverter : ITypeConverter
+    {
+        private static readonly MethodInfo CreateTaskGenericDefinition =
+           typeof(TaskTypeConverter).GetMethod(nameof(CreateTask), BindingFlags.Static | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// Potentially converts an unserializable object to a more serializable form.
+        /// </summary>
+        /// <param name="input">An input object.</param>
+        /// <param name="output">An output object. Will be assigned to a simpler representation of <paramref name="input"/>, if this converter knows how.</param>
+        /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
+        public bool ConvertForRecording(object? input, out object? output)
+        {
+            output = null;
+            if (input is null)
+            {
+                return false;
+            }
+
+            var inputType = input.GetType();
+            if (inputType.IsInstanceOf(typeof(Task<>)))
+            {
+                output = inputType.GetProperty("Result").GetGetMethod().Invoke(input, Type.EmptyTypes);
+                return true;
+            }
+            else if (inputType == typeof(Task))
+            {
+                output = "{void Task}";
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Potentially converts the serializable form of an object back to its unserializable form.
+        /// </summary>
+        /// <param name="deserializedType">The desired deserialized type.</param>
+        /// <param name="input">An input object.</param>
+        /// <param name="output">An output object. Will be reconstituted from its simpler representation as <paramref name="input"/>, if this converter knows how.</param>
+        /// <returns><c>true</c> if the conversion happened, otherwise <c>false</c>. Good for building a chain of responsibility.</returns>
+        public bool ConvertForPlayback(Type deserializedType, object? input, out object? output)
+        {
+            if (deserializedType.IsInstanceOf(typeof(Task<>)))
+            {
+                var typeOfTaskResult = deserializedType.GetGenericArguments()[0];
+                var method = CreateTaskGenericDefinition.MakeGenericMethod(typeOfTaskResult);
+                output = method.Invoke(null, new object?[] { input });
+                return true;
+            }
+            else if (deserializedType == typeof(Task) && "{void Task}".Equals(input))
+            {
+                var task = new Task(() => { });
+                task.Start();
+                task.Wait();
+
+                output = task;
+                return true;
+            }
+
+            output = null;
+            return false;
+        }
+
+        private static Task<T> CreateTask<T>(T value)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            tcs.SetResult(value);
+            return tcs.Task;
+        }
+    }
+}

--- a/src/SelfInitializingFakes/Infrastructure/TypeExtensions.cs
+++ b/src/SelfInitializingFakes/Infrastructure/TypeExtensions.cs
@@ -1,0 +1,27 @@
+namespace SelfInitializingFakes.Infrastructure
+{
+    using System;
+#if FRAMEWORK_WEAK_TYPE_CLASS
+    using System.Reflection;
+#endif
+
+    /// <summary>
+    /// Provides extension methods for <see cref="Type"/>.
+    /// </summary>
+    internal static class TypeExtensions
+    {
+        /// <summary>
+        /// See if this type is an instance of a given open generic type.
+        /// </summary>
+        /// <param name="this">This type argument.</param>
+        /// <param name="genericType">The generic type definition to see if this type is an instance of.</param>
+        /// <returns>Type info of the type argument.</returns>
+        public static bool IsInstanceOf(this Type @this, Type genericType) =>
+#if FRAMEWORK_WEAK_TYPE_CLASS
+            @this.GetTypeInfo().IsGenericType
+#else
+            @this.IsGenericType
+#endif
+            && @this.GetGenericTypeDefinition() == genericType;
+    }
+}

--- a/src/SelfInitializingFakes/SelfInitializingFake.of.T.cs
+++ b/src/SelfInitializingFakes/SelfInitializingFake.of.T.cs
@@ -31,18 +31,21 @@ namespace SelfInitializingFakes
 
             this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
 
+            var typeConverter = new LazyTypeConverter();
             var callsFromRepository = this.repository.Load();
             if (callsFromRepository == null)
             {
                 var wrappedService = serviceFactory.Invoke();
                 this.Object = A.Fake<TService>();
-                this.recordingRule = new RecordingRule(wrappedService);
+                this.recordingRule = new RecordingRule(wrappedService, typeConverter);
                 Fake.GetFakeManager(this.Object).AddRuleFirst(this.recordingRule);
             }
             else
             {
                 this.Object = A.Fake<TService>();
-                Fake.GetFakeManager(this.Object).AddRuleFirst(new PlaybackRule(new Queue<RecordedCall>(callsFromRepository)));
+                Fake.GetFakeManager(this.Object).AddRuleFirst(new PlaybackRule(
+                    new Queue<RecordedCall>(callsFromRepository),
+                    typeConverter));
             }
         }
 

--- a/tests/Acceptance/BinarySerialization.cs
+++ b/tests/Acceptance/BinarySerialization.cs
@@ -3,25 +3,20 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+
     using FluentAssertions;
+    using SelfInitializingFakes.Tests.Acceptance.Helpers;
     using Xbehave;
 
     public static class BinarySerialization
     {
-        public interface IService
-        {
-            void VoidMethod(string s, out int i, ref DateTime dt);
-
-            IDictionary<string, Guid> NonVoidMethod();
-        }
-
         [Scenario]
         public static void SerializeVoidCall(
             string path,
             IRecordedCallRepository repository,
             int voidMethodOutInteger,
             DateTime voidMethodRefDateTime,
-            IDictionary<string, Guid> nonVoidMethodResult)
+            IDictionary<string, Guid> dictionaryMethodResult)
         {
             "Given a file path"
                 .x(() => path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
@@ -32,23 +27,23 @@
             "When I use a self-initializing fake in recording mode"
                 .x(() =>
                 {
-                    using (var fakeService = SelfInitializingFake<IService>.For(() => new Service(), repository))
+                    using (var fakeService = SelfInitializingFake<ISampleService>.For(() => new SampleService(), repository))
                     {
                         DateTime discardDateTime = DateTime.MaxValue;
                         var fake = fakeService.Object;
                         fake.VoidMethod("firstCallKey", out _, ref discardDateTime);
-                        _ = fake.NonVoidMethod();
+                        _ = fake.DictionaryReturningMethod();
                     }
                 });
 
             "And I use a self-initializing fake in playback mode"
                 .x(() =>
                 {
-                    using (var playbackFakeService = SelfInitializingFake<IService>.For<IService>(UnusedFactory, repository))
+                    using (var playbackFakeService = SelfInitializingFake<ISampleService>.For(UnusedFactory, repository))
                     {
                         var fake = playbackFakeService.Object;
                         fake.VoidMethod("firstCallKey", out voidMethodOutInteger, ref voidMethodRefDateTime);
-                        nonVoidMethodResult = fake.NonVoidMethod();
+                        dictionaryMethodResult = fake.DictionaryReturningMethod();
                     }
                 });
 
@@ -57,27 +52,13 @@
                 {
                     voidMethodOutInteger.Should().Be(17);
                     voidMethodRefDateTime.Should().Be(new DateTime(2017, 1, 24));
-                    nonVoidMethodResult.Should()
+                    dictionaryMethodResult.Should()
                         .HaveCount(1).And
                         .ContainKey("key1")
                         .WhichValue.Should().Be(new Guid("6c7d8912-802a-43c0-82a2-cb811058a9bd"));
                 });
         }
 
-        private static IService UnusedFactory() => null!;
-
-        private class Service : IService
-        {
-            public void VoidMethod(string s, out int i, ref DateTime dt)
-            {
-                i = 17;
-                dt = new DateTime(2017, 1, 24);
-            }
-
-            public IDictionary<string, Guid> NonVoidMethod() => new Dictionary<string, Guid>
-            {
-                ["key1"] = new Guid("6c7d8912-802a-43c0-82a2-cb811058a9bd"),
-            };
-        }
+        private static ISampleService UnusedFactory() => null!;
     }
 }

--- a/tests/Acceptance/BinarySerialization.cs
+++ b/tests/Acceptance/BinarySerialization.cs
@@ -8,76 +8,50 @@
     using SelfInitializingFakes.Tests.Acceptance.Helpers;
     using Xbehave;
 
-    public static class BinarySerialization
+    public class BinarySerialization : TypeSerializationTestBase
     {
         [Scenario]
-        public static void SerializeVoidCall(
-            string path,
+        public void SerializeCallWithDictionary(
             IRecordedCallRepository repository,
-            int voidMethodOutInteger,
-            DateTime voidMethodRefDateTime,
-            IDictionary<string, Guid> dictionaryMethodResult,
-            Lazy<int> lazyIntMethodResult,
-            Lazy<string> lazyStringMethodResult,
-            Lazy<int> lazyOutResult)
+            IDictionary<string, Guid> dictionaryMethodResult)
         {
-            "Given a file path"
-                .x(() => path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            "Given a recorded call repository"
+                .x(() => repository = this.CreateRepository());
 
-            "And a BinaryFileRecordedCallRepository targeting that path"
-                .x(() => repository = new BinaryFileRecordedCallRepository(path));
-
-            "When I use a self-initializing fake in recording mode"
+            "When I record a dictionary-returning method via a self-initializing fake"
                 .x(() =>
                 {
                     using (var fakeService = SelfInitializingFake<ISampleService>.For(() => new SampleService(), repository))
                     {
-                        DateTime discardDateTime = DateTime.MaxValue;
                         var fake = fakeService.Object;
-                        fake.VoidMethod("firstCallKey", out _, ref discardDateTime);
                         _ = fake.DictionaryReturningMethod();
-                        _ = fake.LazyIntReturningMethod();
-                        _ = fake.LazyStringReturningMethod();
-                        fake.MethodWithLazyOut(out _);
                     }
                 });
 
-            "And I use a self-initializing fake in playback mode"
+            "And I play back a dictionary-returning method via a self-initializing fake"
                 .x(() =>
                 {
                     using (var playbackFakeService = SelfInitializingFake<ISampleService>.For(UnusedFactory, repository))
                     {
                         var fake = playbackFakeService.Object;
-                        fake.VoidMethod("firstCallKey", out voidMethodOutInteger, ref voidMethodRefDateTime);
                         dictionaryMethodResult = fake.DictionaryReturningMethod();
-                        lazyIntMethodResult = fake.LazyIntReturningMethod();
-                        lazyStringMethodResult = fake.LazyStringReturningMethod();
-                        fake.MethodWithLazyOut(out lazyOutResult);
                     }
                 });
 
             "Then the playback fake returns the recorded out and ref parameters and results"
                 .x(() =>
                 {
-                    voidMethodOutInteger.Should().Be(17);
-                    voidMethodRefDateTime.Should().Be(new DateTime(2017, 1, 24));
-
                     dictionaryMethodResult.Should()
                         .HaveCount(1).And
                         .ContainKey("key1")
                         .WhichValue.Should().Be(new Guid("6c7d8912-802a-43c0-82a2-cb811058a9bd"));
-
-                    lazyIntMethodResult.IsValueCreated.Should().BeFalse();
-                    lazyIntMethodResult.Value.Should().Be(3);
-
-                    lazyStringMethodResult.IsValueCreated.Should().BeFalse();
-                    lazyStringMethodResult.Value.Should().Be("three");
-
-                    lazyOutResult.IsValueCreated.Should().BeFalse();
-                    lazyOutResult.Value.Should().Be(-14);
                 });
         }
 
-        private static ISampleService UnusedFactory() => null!;
+        protected override IRecordedCallRepository CreateRepository()
+        {
+            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml");
+            return new BinaryFileRecordedCallRepository(path);
+        }
     }
 }

--- a/tests/Acceptance/BinarySerialization.cs
+++ b/tests/Acceptance/BinarySerialization.cs
@@ -16,7 +16,10 @@
             IRecordedCallRepository repository,
             int voidMethodOutInteger,
             DateTime voidMethodRefDateTime,
-            IDictionary<string, Guid> dictionaryMethodResult)
+            IDictionary<string, Guid> dictionaryMethodResult,
+            Lazy<int> lazyIntMethodResult,
+            Lazy<string> lazyStringMethodResult,
+            Lazy<int> lazyOutResult)
         {
             "Given a file path"
                 .x(() => path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
@@ -33,6 +36,9 @@
                         var fake = fakeService.Object;
                         fake.VoidMethod("firstCallKey", out _, ref discardDateTime);
                         _ = fake.DictionaryReturningMethod();
+                        _ = fake.LazyIntReturningMethod();
+                        _ = fake.LazyStringReturningMethod();
+                        fake.MethodWithLazyOut(out _);
                     }
                 });
 
@@ -44,6 +50,9 @@
                         var fake = playbackFakeService.Object;
                         fake.VoidMethod("firstCallKey", out voidMethodOutInteger, ref voidMethodRefDateTime);
                         dictionaryMethodResult = fake.DictionaryReturningMethod();
+                        lazyIntMethodResult = fake.LazyIntReturningMethod();
+                        lazyStringMethodResult = fake.LazyStringReturningMethod();
+                        fake.MethodWithLazyOut(out lazyOutResult);
                     }
                 });
 
@@ -52,10 +61,20 @@
                 {
                     voidMethodOutInteger.Should().Be(17);
                     voidMethodRefDateTime.Should().Be(new DateTime(2017, 1, 24));
+
                     dictionaryMethodResult.Should()
                         .HaveCount(1).And
                         .ContainKey("key1")
                         .WhichValue.Should().Be(new Guid("6c7d8912-802a-43c0-82a2-cb811058a9bd"));
+
+                    lazyIntMethodResult.IsValueCreated.Should().BeFalse();
+                    lazyIntMethodResult.Value.Should().Be(3);
+
+                    lazyStringMethodResult.IsValueCreated.Should().BeFalse();
+                    lazyStringMethodResult.Value.Should().Be("three");
+
+                    lazyOutResult.IsValueCreated.Should().BeFalse();
+                    lazyOutResult.Value.Should().Be(-14);
                 });
         }
 

--- a/tests/Acceptance/FileBasedSerializers.cs
+++ b/tests/Acceptance/FileBasedSerializers.cs
@@ -5,19 +5,13 @@
     using System.IO;
     using System.Linq;
 
-    using FakeItEasy;
     using FluentAssertions;
-    using SelfInitializingFakes.Tests.Acceptance.Helper;
+    using SelfInitializingFakes.Tests.Acceptance.Helpers;
     using Xbehave;
     using Xunit;
 
     public static class FileBasedSerializers
     {
-        public interface IService
-        {
-            Guid NonVoidMethod();
-        }
-
         public static IEnumerable<object[]> ConcreteRepositoryTypes() =>
             typeof(FileBasedRecordedCallRepository).GetConcreteSubTypesInAssembly()
                 .Select(t => new object[] { t });
@@ -30,7 +24,7 @@
             string missingChildDirectory,
             string repositoryPath,
             IRecordedCallRepository repository,
-            IService realServiceWhileRecording)
+            ISampleService realServiceWhileRecording)
         {
             "Given a directory that exists"
                 .x(() =>
@@ -53,14 +47,14 @@
                 .x(() => repository = (IRecordedCallRepository)Activator.CreateInstance(concreteRepositoryType, repositoryPath));
 
             "And a real service to wrap while recording"
-                .x(() => realServiceWhileRecording = A.Fake<IService>());
+                .x(() => realServiceWhileRecording = new SampleService());
 
             "When I use a self-initializing fake in recording mode"
                 .x(() =>
                 {
-                    using var fakeService = SelfInitializingFake<IService>.For(() => realServiceWhileRecording, repository);
+                    using var fakeService = SelfInitializingFake<ISampleService>.For(() => realServiceWhileRecording, repository);
                     var fake = fakeService.Object;
-                    _ = fake.NonVoidMethod();
+                    _ = fake.GuidReturningMethod();
                 });
 
             "Then the repository file is created"
@@ -75,7 +69,7 @@
             string pathComponent1,
             string pathComponent2,
             IRecordedCallRepository repository,
-            IService realServiceWhileRecording)
+            ISampleService realServiceWhileRecording)
         {
             "Given a base directory"
                 .x(() => baseDirectory = Path.GetTempPath());
@@ -94,14 +88,14 @@
                     pathComponent2));
 
             "And a real service to wrap while recording"
-                .x(() => realServiceWhileRecording = A.Fake<IService>());
+                .x(() => realServiceWhileRecording = new SampleService());
 
             "When I use a self-initializing fake in recording mode"
                 .x(() =>
                 {
-                    using var fakeService = SelfInitializingFake<IService>.For(() => realServiceWhileRecording, repository);
+                    using var fakeService = SelfInitializingFake<ISampleService>.For(() => realServiceWhileRecording, repository);
                     var fake = fakeService.Object;
-                    _ = fake.NonVoidMethod();
+                    _ = fake.GuidReturningMethod();
                 });
 
             "Then the desired repository file is created"

--- a/tests/Acceptance/Helpers/ISampleService.cs
+++ b/tests/Acceptance/Helpers/ISampleService.cs
@@ -21,5 +21,7 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
         Task TaskReturningMethod();
 
         Task<int> TaskIntReturningMethod();
+
+        Lazy<Task<int>> LazyTaskIntReturningMethod();
     }
 }

--- a/tests/Acceptance/Helpers/ISampleService.cs
+++ b/tests/Acceptance/Helpers/ISampleService.cs
@@ -10,5 +10,11 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
         Guid GuidReturningMethod();
 
         IDictionary<string, Guid> DictionaryReturningMethod();
+
+        Lazy<int> LazyIntReturningMethod();
+
+        Lazy<string> LazyStringReturningMethod();
+
+        void MethodWithLazyOut(out Lazy<int> lazyInt);
     }
 }

--- a/tests/Acceptance/Helpers/ISampleService.cs
+++ b/tests/Acceptance/Helpers/ISampleService.cs
@@ -23,5 +23,7 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
         Task<int> TaskIntReturningMethod();
 
         Lazy<Task<int>> LazyTaskIntReturningMethod();
+
+        Task<Lazy<int>> TaskLazyIntReturningMethod();
     }
 }

--- a/tests/Acceptance/Helpers/ISampleService.cs
+++ b/tests/Acceptance/Helpers/ISampleService.cs
@@ -2,6 +2,7 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     public interface ISampleService
     {
@@ -16,5 +17,9 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
         Lazy<string> LazyStringReturningMethod();
 
         void MethodWithLazyOut(out Lazy<int> lazyInt);
+
+        Task TaskReturningMethod();
+
+        Task<int> TaskIntReturningMethod();
     }
 }

--- a/tests/Acceptance/Helpers/ISampleService.cs
+++ b/tests/Acceptance/Helpers/ISampleService.cs
@@ -1,0 +1,14 @@
+namespace SelfInitializingFakes.Tests.Acceptance.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+
+    public interface ISampleService
+    {
+        void VoidMethod(string s, out int i, ref DateTime dt);
+
+        Guid GuidReturningMethod();
+
+        IDictionary<string, Guid> DictionaryReturningMethod();
+    }
+}

--- a/tests/Acceptance/Helpers/SampleService.cs
+++ b/tests/Acceptance/Helpers/SampleService.cs
@@ -1,0 +1,21 @@
+namespace SelfInitializingFakes.Tests.Acceptance.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class SampleService : ISampleService
+    {
+        public void VoidMethod(string s, out int i, ref DateTime dt)
+        {
+            i = 17;
+            dt = new DateTime(2017, 1, 24);
+        }
+
+        public Guid GuidReturningMethod() => new Guid("5b61d48f-e9e5-49ad-9c51-a9aae056aa84");
+
+        public IDictionary<string, Guid> DictionaryReturningMethod() => new Dictionary<string, Guid>
+            {
+                ["key1"] = new Guid("6c7d8912-802a-43c0-82a2-cb811058a9bd"),
+            };
+    }
+}

--- a/tests/Acceptance/Helpers/SampleService.cs
+++ b/tests/Acceptance/Helpers/SampleService.cs
@@ -14,8 +14,14 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
         public Guid GuidReturningMethod() => new Guid("5b61d48f-e9e5-49ad-9c51-a9aae056aa84");
 
         public IDictionary<string, Guid> DictionaryReturningMethod() => new Dictionary<string, Guid>
-            {
-                ["key1"] = new Guid("6c7d8912-802a-43c0-82a2-cb811058a9bd"),
-            };
+        {
+            ["key1"] = new Guid("6c7d8912-802a-43c0-82a2-cb811058a9bd"),
+        };
+
+        public Lazy<int> LazyIntReturningMethod() => new Lazy<int>(() => 3);
+
+        public Lazy<string> LazyStringReturningMethod() => new Lazy<string>(() => "three");
+
+        public void MethodWithLazyOut(out Lazy<int> lazyInt) => lazyInt = new Lazy<int>(() => -14);
     }
 }

--- a/tests/Acceptance/Helpers/SampleService.cs
+++ b/tests/Acceptance/Helpers/SampleService.cs
@@ -25,7 +25,7 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
 
         public void MethodWithLazyOut(out Lazy<int> lazyInt) => lazyInt = new Lazy<int>(() => -14);
 
-        public Task TaskReturningMethod() => Task<string>.FromResult("void Task");
+        public Task TaskReturningMethod() => Task.Delay(0);
 
         public Task<int> TaskIntReturningMethod() => Task<int>.FromResult(5);
     }

--- a/tests/Acceptance/Helpers/SampleService.cs
+++ b/tests/Acceptance/Helpers/SampleService.cs
@@ -30,5 +30,7 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
         public Task<int> TaskIntReturningMethod() => Task<int>.FromResult(5);
 
         public Lazy<Task<int>> LazyTaskIntReturningMethod() => new Lazy<Task<int>>(() => Task<int>.FromResult(19));
+
+        public Task<Lazy<int>> TaskLazyIntReturningMethod() => Task<Lazy<int>>.FromResult(new Lazy<int>(() => 18));
     }
 }

--- a/tests/Acceptance/Helpers/SampleService.cs
+++ b/tests/Acceptance/Helpers/SampleService.cs
@@ -2,6 +2,7 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     public class SampleService : ISampleService
     {
@@ -23,5 +24,9 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
         public Lazy<string> LazyStringReturningMethod() => new Lazy<string>(() => "three");
 
         public void MethodWithLazyOut(out Lazy<int> lazyInt) => lazyInt = new Lazy<int>(() => -14);
+
+        public Task TaskReturningMethod() => Task<string>.FromResult("void Task");
+
+        public Task<int> TaskIntReturningMethod() => Task<int>.FromResult(5);
     }
 }

--- a/tests/Acceptance/Helpers/SampleService.cs
+++ b/tests/Acceptance/Helpers/SampleService.cs
@@ -28,5 +28,7 @@ namespace SelfInitializingFakes.Tests.Acceptance.Helpers
         public Task TaskReturningMethod() => Task.Delay(0);
 
         public Task<int> TaskIntReturningMethod() => Task<int>.FromResult(5);
+
+        public Lazy<Task<int>> LazyTaskIntReturningMethod() => new Lazy<Task<int>>(() => Task<int>.FromResult(19));
     }
 }

--- a/tests/Acceptance/Helpers/TypeExtensions.cs
+++ b/tests/Acceptance/Helpers/TypeExtensions.cs
@@ -1,4 +1,4 @@
-namespace SelfInitializingFakes.Tests.Acceptance.Helper
+namespace SelfInitializingFakes.Tests.Acceptance.Helpers
 {
     using System;
     using System.Collections.Generic;

--- a/tests/Acceptance/TypeSerializationTestBase.cs
+++ b/tests/Acceptance/TypeSerializationTestBase.cs
@@ -19,7 +19,8 @@ namespace SelfInitializingFakes.Tests.Acceptance
             Lazy<string> lazyStringMethodResult,
             Lazy<int> lazyOutResult,
             Task taskResult,
-            Task<int> taskIntResult)
+            Task<int> taskIntResult,
+            Lazy<Task<int>> lazyTaskIntResult)
         {
             "Given a recorded call repository"
                 .x(() => repository = this.CreateRepository());
@@ -39,6 +40,7 @@ namespace SelfInitializingFakes.Tests.Acceptance
                         fake.MethodWithLazyOut(out _);
                         _ = fake.TaskReturningMethod();
                         _ = fake.TaskIntReturningMethod();
+                        _ = fake.LazyTaskIntReturningMethod();
                     }
                 });
 
@@ -55,6 +57,7 @@ namespace SelfInitializingFakes.Tests.Acceptance
                         fake.MethodWithLazyOut(out lazyOutResult);
                         taskResult = fake.TaskReturningMethod();
                         taskIntResult = fake.TaskIntReturningMethod();
+                        lazyTaskIntResult = fake.LazyTaskIntReturningMethod();
                     }
                 });
 
@@ -77,6 +80,10 @@ namespace SelfInitializingFakes.Tests.Acceptance
 
                     taskIntResult.IsCompleted.Should().BeTrue();
                     taskIntResult.Result.Should().Be(5);
+
+                    lazyTaskIntResult.IsValueCreated.Should().BeFalse();
+                    lazyTaskIntResult.Value.IsCompleted.Should().BeTrue();
+                    lazyTaskIntResult.Value.Result.Should().Be(19);
                 });
         }
 

--- a/tests/Acceptance/TypeSerializationTestBase.cs
+++ b/tests/Acceptance/TypeSerializationTestBase.cs
@@ -1,0 +1,74 @@
+namespace SelfInitializingFakes.Tests.Acceptance
+{
+    using System;
+    using System.Collections.Generic;
+
+    using FluentAssertions;
+    using SelfInitializingFakes.Tests.Acceptance.Helpers;
+    using Xbehave;
+
+    public abstract class TypeSerializationTestBase
+    {
+        [Scenario]
+        public void SerializeCommonCalls(
+            IRecordedCallRepository repository,
+            int voidMethodOutInteger,
+            DateTime voidMethodRefDateTime,
+            Lazy<int> lazyIntMethodResult,
+            Lazy<string> lazyStringMethodResult,
+            Lazy<int> lazyOutResult,
+            Task taskResult,
+            Task<int> taskIntResult)
+        {
+            "Given a recorded call repository"
+                .x(() => repository = this.CreateRepository());
+
+            "When I use a self-initializing fake in recording mode"
+                .x(() =>
+                {
+                    using (var fakeService = SelfInitializingFake<ISampleService>.For(() => new SampleService(), repository))
+                    {
+                        DateTime discardDateTime = DateTime.MaxValue;
+                        var fake = fakeService.Object;
+                        fake.VoidMethod("firstCallKey", out _, ref discardDateTime);
+                        _ = fake.LazyIntReturningMethod();
+                        _ = fake.LazyStringReturningMethod();
+                        fake.MethodWithLazyOut(out _);
+                    }
+                });
+
+            "And I use a self-initializing fake in playback mode"
+                .x(() =>
+                {
+                    using (var playbackFakeService = SelfInitializingFake<ISampleService>.For(UnusedFactory, repository))
+                    {
+                        var fake = playbackFakeService.Object;
+                        fake.VoidMethod("firstCallKey", out voidMethodOutInteger, ref voidMethodRefDateTime);
+                        lazyIntMethodResult = fake.LazyIntReturningMethod();
+                        lazyStringMethodResult = fake.LazyStringReturningMethod();
+                        fake.MethodWithLazyOut(out lazyOutResult);
+                    }
+                });
+
+            "Then the playback fake returns the recorded out and ref parameters and results"
+                .x(() =>
+                {
+                    voidMethodOutInteger.Should().Be(17);
+                    voidMethodRefDateTime.Should().Be(new DateTime(2017, 1, 24));
+
+                    lazyIntMethodResult.IsValueCreated.Should().BeFalse();
+                    lazyIntMethodResult.Value.Should().Be(3);
+
+                    lazyStringMethodResult.IsValueCreated.Should().BeFalse();
+                    lazyStringMethodResult.Value.Should().Be("three");
+
+                    lazyOutResult.IsValueCreated.Should().BeFalse();
+                    lazyOutResult.Value.Should().Be(-14);
+                });
+        }
+
+        protected static ISampleService UnusedFactory() => null!;
+
+        protected abstract IRecordedCallRepository CreateRepository();
+    }
+}

--- a/tests/Acceptance/TypeSerializationTestBase.cs
+++ b/tests/Acceptance/TypeSerializationTestBase.cs
@@ -2,6 +2,7 @@ namespace SelfInitializingFakes.Tests.Acceptance
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     using FluentAssertions;
     using SelfInitializingFakes.Tests.Acceptance.Helpers;
@@ -29,11 +30,15 @@ namespace SelfInitializingFakes.Tests.Acceptance
                     using (var fakeService = SelfInitializingFake<ISampleService>.For(() => new SampleService(), repository))
                     {
                         DateTime discardDateTime = DateTime.MaxValue;
+
                         var fake = fakeService.Object;
+
                         fake.VoidMethod("firstCallKey", out _, ref discardDateTime);
                         _ = fake.LazyIntReturningMethod();
                         _ = fake.LazyStringReturningMethod();
                         fake.MethodWithLazyOut(out _);
+                        _ = fake.TaskReturningMethod();
+                        _ = fake.TaskIntReturningMethod();
                     }
                 });
 
@@ -43,10 +48,13 @@ namespace SelfInitializingFakes.Tests.Acceptance
                     using (var playbackFakeService = SelfInitializingFake<ISampleService>.For(UnusedFactory, repository))
                     {
                         var fake = playbackFakeService.Object;
+
                         fake.VoidMethod("firstCallKey", out voidMethodOutInteger, ref voidMethodRefDateTime);
                         lazyIntMethodResult = fake.LazyIntReturningMethod();
                         lazyStringMethodResult = fake.LazyStringReturningMethod();
                         fake.MethodWithLazyOut(out lazyOutResult);
+                        taskResult = fake.TaskReturningMethod();
+                        taskIntResult = fake.TaskIntReturningMethod();
                     }
                 });
 
@@ -64,6 +72,11 @@ namespace SelfInitializingFakes.Tests.Acceptance
 
                     lazyOutResult.IsValueCreated.Should().BeFalse();
                     lazyOutResult.Value.Should().Be(-14);
+
+                    taskResult.IsCompleted.Should().BeTrue();
+
+                    taskIntResult.IsCompleted.Should().BeTrue();
+                    taskIntResult.Result.Should().Be(5);
                 });
         }
 

--- a/tests/Acceptance/TypeSerializationTestBase.cs
+++ b/tests/Acceptance/TypeSerializationTestBase.cs
@@ -20,7 +20,8 @@ namespace SelfInitializingFakes.Tests.Acceptance
             Lazy<int> lazyOutResult,
             Task taskResult,
             Task<int> taskIntResult,
-            Lazy<Task<int>> lazyTaskIntResult)
+            Lazy<Task<int>> lazyTaskIntResult,
+            Task<Lazy<int>> taskLazyIntResult)
         {
             "Given a recorded call repository"
                 .x(() => repository = this.CreateRepository());
@@ -41,6 +42,7 @@ namespace SelfInitializingFakes.Tests.Acceptance
                         _ = fake.TaskReturningMethod();
                         _ = fake.TaskIntReturningMethod();
                         _ = fake.LazyTaskIntReturningMethod();
+                        _ = fake.TaskLazyIntReturningMethod();
                     }
                 });
 
@@ -58,6 +60,7 @@ namespace SelfInitializingFakes.Tests.Acceptance
                         taskResult = fake.TaskReturningMethod();
                         taskIntResult = fake.TaskIntReturningMethod();
                         lazyTaskIntResult = fake.LazyTaskIntReturningMethod();
+                        taskLazyIntResult = fake.TaskLazyIntReturningMethod();
                     }
                 });
 
@@ -84,6 +87,10 @@ namespace SelfInitializingFakes.Tests.Acceptance
                     lazyTaskIntResult.IsValueCreated.Should().BeFalse();
                     lazyTaskIntResult.Value.IsCompleted.Should().BeTrue();
                     lazyTaskIntResult.Value.Result.Should().Be(19);
+
+                    taskLazyIntResult.IsCompleted.Should().BeTrue();
+                    taskLazyIntResult.Result.IsValueCreated.Should().BeFalse();
+                    taskLazyIntResult.Result.Value.Should().Be(18);
                 });
         }
 

--- a/tests/Acceptance/XmlSerialization.cs
+++ b/tests/Acceptance/XmlSerialization.cs
@@ -15,7 +15,10 @@
             IRecordedCallRepository repository,
             int voidMethodOutInteger,
             DateTime voidMethodRefDateTime,
-            Guid guidMethodResult)
+            Guid guidMethodResult,
+            Lazy<int> lazyIntMethodResult,
+            Lazy<string> lazyStringMethodResult,
+            Lazy<int> lazyOutResult)
         {
             "Given a file path"
                 .x(() => path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml"));
@@ -32,6 +35,9 @@
                         var fake = fakeService.Object;
                         fake.VoidMethod("recordingCallKey", out _, ref discardDateTime);
                         _ = fake.GuidReturningMethod();
+                        _ = fake.LazyIntReturningMethod();
+                        _ = fake.LazyStringReturningMethod();
+                        fake.MethodWithLazyOut(out _);
                     }
                 });
 
@@ -43,6 +49,9 @@
                         var fake = playbackFakeService.Object;
                         fake.VoidMethod("blah", out voidMethodOutInteger, ref voidMethodRefDateTime);
                         guidMethodResult = fake.GuidReturningMethod();
+                        lazyIntMethodResult = fake.LazyIntReturningMethod();
+                        lazyStringMethodResult = fake.LazyStringReturningMethod();
+                        fake.MethodWithLazyOut(out lazyOutResult);
                     }
                 });
 
@@ -51,7 +60,17 @@
                 {
                     voidMethodOutInteger.Should().Be(17);
                     voidMethodRefDateTime.Should().Be(new DateTime(2017, 1, 24));
+
                     guidMethodResult.Should().Be(new Guid("5b61d48f-e9e5-49ad-9c51-a9aae056aa84"));
+
+                    lazyIntMethodResult.IsValueCreated.Should().BeFalse();
+                    lazyIntMethodResult.Value.Should().Be(3);
+
+                    lazyStringMethodResult.IsValueCreated.Should().BeFalse();
+                    lazyStringMethodResult.Value.Should().Be("three");
+
+                    lazyOutResult.IsValueCreated.Should().BeFalse();
+                    lazyOutResult.Value.Should().Be(-14);
                 });
         }
 

--- a/tests/Acceptance/XmlSerialization.cs
+++ b/tests/Acceptance/XmlSerialization.cs
@@ -3,77 +3,12 @@
     using System;
     using System.IO;
 
-    using FluentAssertions;
-    using SelfInitializingFakes.Tests.Acceptance.Helpers;
-    using Xbehave;
-
-    public static class XmlSerialization
+    public class XmlSerialization : TypeSerializationTestBase
     {
-        [Scenario]
-        public static void SerializeVoidCall(
-            string path,
-            IRecordedCallRepository repository,
-            int voidMethodOutInteger,
-            DateTime voidMethodRefDateTime,
-            Guid guidMethodResult,
-            Lazy<int> lazyIntMethodResult,
-            Lazy<string> lazyStringMethodResult,
-            Lazy<int> lazyOutResult)
+        protected override IRecordedCallRepository CreateRepository()
         {
-            "Given a file path"
-                .x(() => path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml"));
-
-            "And a XmlFileRecordedCallRepository targeting that path"
-                .x(() => repository = new XmlFileRecordedCallRepository(path));
-
-            "When I use a self-initializing fake in recording mode"
-                .x(() =>
-                {
-                    using (var fakeService = SelfInitializingFake<ISampleService>.For(() => new SampleService(), repository))
-                    {
-                        DateTime discardDateTime = DateTime.MaxValue;
-                        var fake = fakeService.Object;
-                        fake.VoidMethod("recordingCallKey", out _, ref discardDateTime);
-                        _ = fake.GuidReturningMethod();
-                        _ = fake.LazyIntReturningMethod();
-                        _ = fake.LazyStringReturningMethod();
-                        fake.MethodWithLazyOut(out _);
-                    }
-                });
-
-            "And I use a self-initializing fake in playback mode"
-                .x(() =>
-                {
-                    using (var playbackFakeService = SelfInitializingFake<ISampleService>.For<ISampleService>(UnusedFactory, repository))
-                    {
-                        var fake = playbackFakeService.Object;
-                        fake.VoidMethod("blah", out voidMethodOutInteger, ref voidMethodRefDateTime);
-                        guidMethodResult = fake.GuidReturningMethod();
-                        lazyIntMethodResult = fake.LazyIntReturningMethod();
-                        lazyStringMethodResult = fake.LazyStringReturningMethod();
-                        fake.MethodWithLazyOut(out lazyOutResult);
-                    }
-                });
-
-            "Then the playback fake returns the recorded out and ref parameters and results"
-                .x(() =>
-                {
-                    voidMethodOutInteger.Should().Be(17);
-                    voidMethodRefDateTime.Should().Be(new DateTime(2017, 1, 24));
-
-                    guidMethodResult.Should().Be(new Guid("5b61d48f-e9e5-49ad-9c51-a9aae056aa84"));
-
-                    lazyIntMethodResult.IsValueCreated.Should().BeFalse();
-                    lazyIntMethodResult.Value.Should().Be(3);
-
-                    lazyStringMethodResult.IsValueCreated.Should().BeFalse();
-                    lazyStringMethodResult.Value.Should().Be("three");
-
-                    lazyOutResult.IsValueCreated.Should().BeFalse();
-                    lazyOutResult.Value.Should().Be(-14);
-                });
+            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml");
+            return new XmlFileRecordedCallRepository(path);
         }
-
-        private static ISampleService UnusedFactory() => null!;
     }
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -44,4 +44,8 @@
     <Compile Remove="..\Acceptance\BinarySerialization.cs" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <DefineConstants>$(DefineConstants);FRAMEWORK_TYPE_LACKS_ISABSTRACT</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/tests/SelfInitializingFakes.Tests.FIE.3.0.0/SelfInitializingFakes.Tests.FIE.3.0.0.csproj
+++ b/tests/SelfInitializingFakes.Tests.FIE.3.0.0/SelfInitializingFakes.Tests.FIE.3.0.0.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>SelfInitializingFakes.Tests.FIE.3.0.0</AssemblyName>
     <PackageId>SelfInitializingFakes.Tests.FIE.3.0.0</PackageId>
-    <DefineConstants>$(DefineConstants);BUG_ASSIGNING_REF_VALUE_CLEARS_INCOMING_VALUE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #81.

This solution is independent of serializers, and supports `Task`s, `Tasks<T>`s, and `Lazy<T>`s, including any (directly) nested combinations of these, e.g. `Lazy<Task<T>>`.
However, these are only supported as the "top": as a direct return value, or out or ref parameter. A `List<Task<T>>` would not be handled.