### PR TITLE
Use relative path for nuget output

### DIFF
--- a/tools/targets/Program.cs
+++ b/tools/targets/Program.cs
@@ -18,7 +18,7 @@ internal class Program
         var versionInfoFile = "./src/VersionInfo.cs";
 
         var logsDirectory = "./artifacts/logs";
-        var outputDirectory = Path.GetFullPath("./artifacts/output");
+        var outputDirectory = "./artifacts/output";
         var testsDirectory = "./artifacts/tests";
 
         string version = string.Empty;


### PR DESCRIPTION
Otherwise, spaces in the current directory break the pack target